### PR TITLE
Fixes for README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dump.sql.gz:
 .PHONY: services
 services:
 	docker-compose up -d
-	@echo Info: To (re-)init DB run "make initdb" now.
+	@echo Info: To \(re-\)init DB run "make initdb" now.
 
 
 .PHONY: initdb

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ You'll now have four Docker containers running the PostgreSQL databases for cnx-
 
     docker-compose ps
 
-To stop any of the docker containers, obtain the CONTAINER ID by running `docker container ls`, then:
+To stop any of the docker containers:
 
-    docker stop [CONTAINER ID]
+    docker-compose stop [SERVICE...]  # e.g. docker-compose stop cnx-db
 
 ### Initialize DB on first run
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl localhost:5000/events
 
 2. Add event:
 ```
-$ curl -d '{"id_hash": "0889907c-f0ef-496a-bcb8-2a5bb121717f"}' -H "Content-Type: application/json" -X POST http://localhost:5000/events
+$ curl -d '{"ident_hash": "0889907c-f0ef-496a-bcb8-2a5bb121717f"}' -H "Content-Type: application/json" -X POST http://localhost:5000/events
 ```
 
 3. See event:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,6 @@ services:
       - pg-data:/var/lib/postgresql/data
     ports:
       - "15432:5432"
-    environment:
-      - DB_URL=postgresql://rhaptos@/repository
-      - DB_SUPER_URL=postgresql://rhaptos_admin@/repository
 
   content-events-api:
     build: api/


### PR DESCRIPTION
- Fix "make services" /bin/sh syntax error

  When I tried to run `make services`, I get:
  
  ```
  docker-compose up -d
  rapspikeconcourse_cnx-rabbitmq_1 is up-to-date
  rapspikeconcourse_concourse-db_1 is up-to-date
  rapspikeconcourse_cnx-db_1 is up-to-date
  rapspikeconcourse_content-events-api_1 is up-to-date
  rapspikeconcourse_concourse_1 is up-to-date
  /bin/sh: 1: Syntax error: "(" unexpected
  Makefile:19: recipe for target 'services' failed
  make: *** [services] Error 2
  ```
  
  Fix the syntax error by escaping the parentheses with a backslash.

- Change docker stop to docker-compose stop in README

  To make it consistent with all the other commands in README that are
  already using `docker-compose`, change `docker stop [CONTAINER ID]` to
  `docker-compose stop [SERVICE...]`.

- Fix content event add event API payload in README

  When using the curl command from README, the content event app returned:
  
  ```
  <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
  <title>400 Bad Request</title>
  <h1>Bad Request</h1>
  <p>Missing 'ident_hash'</p>
  ```
  
  Change `id_hash` to `ident_hash` in the content event API payload in README.

- Remove DB_URL env vars from cnx-db in docker-compose.yml

  `DB_URL` and `DB_SUPER_URL` are already defined in the cnx-db docker
  image so we should just use them.

