### PR TITLE
fixed show-queued-pipeline trigger by using version: every

### DIFF
--- a/concourse/show-queued-pipeline.yml
+++ b/concourse/show-queued-pipeline.yml
@@ -20,6 +20,7 @@ jobs:
     plan:
       - get: content-events-queued
         trigger: true
+        version: every
       - task: show-queued
         config:
           platform: linux


### PR DESCRIPTION
The default for concourse get resources is to use latest version. With the use of `version: every` concourse will step over each new version detected.

https://concourse-ci.org/get-step.html#get-step-version