### PR TITLE
Store the task within the container

### DIFF
--- a/bridge/src/setup.py
+++ b/bridge/src/setup.py
@@ -40,7 +40,7 @@ SETUP_KWARGS = dict(
 
 setup(
     name='bridge',
-    version='1.0.0',
+    version='1.1.0',
     author='OpenStax',
     url="https://github.com/openstax",
     license='LGPL',

--- a/bridge/tasks/extract-content.yml
+++ b/bridge/tasks/extract-content.yml
@@ -1,0 +1,31 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: openstax/rap-spike-bridge
+    tag: latest
+
+params:
+  DB_URL: ((db_url))
+
+inputs:
+  - name: identifier-struct
+
+outputs:
+  - name: content
+
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      # DEBUG info
+      env
+      ls -lah
+      ls -lah identifier-struct
+      # Working logic
+      echo "Extracting: $(cat identifier-struct/ident_hash)"
+      bridge extract -o content/ $(cat identifier-struct/ident_hash)

--- a/concourse/extract-content-s3.yml
+++ b/concourse/extract-content-s3.yml
@@ -5,6 +5,14 @@
 ###
 
 resources:
+
+  - name: bridge
+    type: docker-image
+    source:
+      repository: openstax/rap-spike-bridge
+      # tag: latest
+      tag: 1.1.0
+
   - name: storage
     type: s3-simple
     source:
@@ -56,28 +64,18 @@ jobs:
                 echo $IDENT_HASH > mock-struct/ident_hash
                 touch mock-struct/event.json
 
+      - get: bridge
+
       - task: extraction
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: openstax/rap-spike-bridge
-              tag: latest
-          params:
-            DB_URL: "postgresql://rhaptos@cnx-db/repository"
-          inputs:
-            - name: mock-struct
-          outputs:
-            - name: content
-          run:
-            path: sh
-            args:
-              - -c
-              - |
-                ls -lah mock-struct
-                cp mock-struct/ident_hash content/
-                bridge extract $(cat mock-struct/ident_hash) -o content/
+        image: bridge
+        file: bridge/rootfs/tasks/extract-content.yml
+        vars:
+          db_url: "postgresql://rhaptos@cnx-db/repository"
+        input_mapping:
+          identifier-struct: mock-struct
+        output_mapping:
+          content: content
+
       - put: storage
         inputs:
           - content

--- a/concourse/show-extracted-content.yml
+++ b/concourse/show-extracted-content.yml
@@ -1,6 +1,25 @@
 ---
 
 ###
+#  Resources
+###
+
+resources:
+
+  - name: bridge
+    type: docker-image
+    source:
+      repository: openstax/rap-spike-bridge
+      # tag: latest
+      tag: 1.1.0
+
+###
+#  Resource Types
+###
+
+resource_types:
+
+###
 #  Pipeline Jobs
 ###
 
@@ -29,29 +48,18 @@ jobs:
                 touch mock-struct/id
                 echo $IDENT_HASH > mock-struct/ident_hash
                 touch mock-struct/event.json
+        
+      - get: bridge
 
       - task: extraction
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: openstax/rap-spike-bridge
-              tag: latest
-          params:
-            DB_URL: "postgresql://rhaptos@cnx-db/repository"
-          inputs:
-            - name: mock-struct
-          outputs:
-            - name: content
-          run:
-            path: sh
-            args:
-              - -c
-              - |
-                ls -lah mock-struct
-                cp mock-struct/ident_hash content/
-                bridge extract $(cat mock-struct/ident_hash) -o content/
+        image: bridge
+        file: bridge/rootfs/tasks/extract-content.yml
+        vars:
+          db_url: "postgresql://rhaptos@cnx-db/repository"
+        input_mapping:
+          identifier-struct: mock-struct
+        output_mapping:
+          content: content
 
       - task: print
         config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     command: tail -f /dev/null
     volumes:
       - ./bridge/src/bridge:/usr/local/lib/python3.7/site-packages/bridge
+      - ./bridge/tasks:/tasks
 
 volumes:
   pg-data:


### PR DESCRIPTION
This puts the Concourse task file in the container. So we're
essentially able to call the task from the container and use the container
to run the task.

This task file makes the execution reusable. Kinda like a reusable function.
See the `show-extracted-content.yml` as an example.